### PR TITLE
fix: restore production chess/mails, eth-balance, and portfolio/resume UX

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -56,13 +56,13 @@ Chromium, so the form would stay blocked on a missing token.
 
 ## Specs
 
-| Spec                   | Tier                                                                         |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `smoke.spec.ts`        | Shell renders, no uncaught errors                                            |
-| `public-pages.spec.ts` | `/privacy`, `/terms`, `/portfolio`, `/blog`, `/diaries`, `/contact`, `/web3` |
-| `public-api.spec.ts`   | `/api/diary`, `/api/blog` + 401s for guarded reads                           |
-| `auth-guard.spec.ts`   | `src/proxy.ts` redirects for `/chess`, `/mails`, `/diary`                    |
-| `contact.spec.ts`      | Contact validation with Turnstile test keys                                  |
+| Spec                   | Tier                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `smoke.spec.ts`        | Shell renders, no uncaught errors                                                                                           |
+| `public-pages.spec.ts` | `/privacy`, `/terms`, `/portfolio` (Skills default + scroll reset), `/blog`, `/diaries`, `/contact`, `/web3`, resume prompt |
+| `public-api.spec.ts`   | `/api/diary`, `/api/blog` + 401s for guarded reads                                                                          |
+| `auth-guard.spec.ts`   | `src/proxy.ts` redirects for `/chess`, `/mails`, `/diary` (signed-out). Authenticated admin cases live in Vitest.           |
+| `contact.spec.ts`      | Contact validation with Turnstile test keys                                                                                 |
 
 ## Deliberately not covered here
 

--- a/e2e/auth-guard.spec.ts
+++ b/e2e/auth-guard.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/test'
 
-/** Routes guarded by `src/proxy.ts` for signed-out visitors. */
+/** Routes guarded by `src/proxy.ts` for signed-out visitors.
+ * Authenticated admin access to /chess and /mails is covered in
+ * `src/proxy.test.ts` and `src/lib/route-guard.test.ts`.
+ */
 const guardedRoutes = [
   '/chess',
   '/mails',

--- a/e2e/public-pages.spec.ts
+++ b/e2e/public-pages.spec.ts
@@ -53,4 +53,50 @@ test.describe('public pages', () => {
     expect(response?.status()).toBeLessThan(400)
     await expect(page.locator('main')).toBeVisible()
   })
+
+  test('/portfolio opens on Skills', async ({ page }) => {
+    await page.goto('/portfolio')
+
+    await expect(
+      page.getByRole('heading', { name: 'Skills', exact: true })
+    ).toBeVisible()
+    await expect(page.getByText('Nothing to see here.')).toHaveCount(0)
+  })
+
+  test('/portfolio resets showcase scroll when switching sections', async ({
+    page
+  }) => {
+    await page.goto('/portfolio')
+
+    const panel = page.getByTestId('portfolio-showcase')
+    await expect(panel).toBeVisible()
+
+    const scrolled = await panel.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      return element.scrollTop
+    })
+    expect(scrolled).toBeGreaterThan(0)
+
+    await page.getByRole('button', { name: 'Projects' }).click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Projects', exact: true })
+    ).toBeVisible()
+    await expect(panel).toHaveJSProperty('scrollTop', 0)
+  })
+
+  test('resume dock icon asks before downloading', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'Resume' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Resume' })
+    await expect(dialog).toBeVisible()
+    await expect(
+      dialog.getByRole('link', { name: 'Download PDF' })
+    ).toHaveAttribute('href', '/pdfs/updated-resume.pdf')
+    await expect(
+      dialog.getByRole('link', { name: 'View in browser' })
+    ).toHaveAttribute('href', '/resume/resume.html')
+  })
 })

--- a/src/app/_components/HomeAppIcon.tsx
+++ b/src/app/_components/HomeAppIcon.tsx
@@ -1,3 +1,4 @@
+import ResumeHomeIcon from '@/app/_components/ResumeHomeIcon'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -12,11 +13,14 @@ type HomeAppIconProps = {
 const HomeAppIcon = ({ name, img, href, size, download }: HomeAppIconProps) => {
   const isMobile = size === 'mobile'
 
+  if (download) {
+    return <ResumeHomeIcon name={name} img={img} size={size} />
+  }
+
   return (
     <Link
       href={href}
       className={`grid place-items-center w-full ${isMobile ? 'gap-y-1.5' : 'gap-y-2'}`}
-      {...(download ? { target: '_blank', download: true } : {})}
     >
       <div className={isMobile ? undefined : 'block'}>
         <div

--- a/src/app/_components/ResumeHomeIcon.tsx
+++ b/src/app/_components/ResumeHomeIcon.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import ResumeActionModal from '@/components/ResumeActionModal'
+import Image from 'next/image'
+import { useState } from 'react'
+
+type ResumeHomeIconProps = {
+  name: string
+  img: string
+  size: 'mobile' | 'tablet'
+}
+
+const ResumeHomeIcon = ({ name, img, size }: ResumeHomeIconProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const isMobile = size === 'mobile'
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={name}
+        onClick={() => setIsOpen(true)}
+        className={`grid place-items-center w-full ${isMobile ? 'gap-y-1.5' : 'gap-y-2'}`}
+      >
+        <div className={isMobile ? undefined : 'block'}>
+          <div
+            className={`relative cursor-pointer ${
+              isMobile ? 'size-11.25 xs:size-12.5' : 'h-15 w-15'
+            }`}
+          >
+            <Image
+              alt={name}
+              src={img}
+              fill
+              priority
+              sizes={isMobile ? '45px xs:50px' : '60px'}
+            />
+          </div>
+        </div>
+        <span
+          className={`font-normal text-white text-center ${
+            isMobile ? 'text-[9px] leading-tight' : 'text-sm'
+          }`}
+        >
+          {name}
+        </span>
+      </button>
+      <ResumeActionModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  )
+}
+
+export default ResumeHomeIcon

--- a/src/app/api/eth-balance/route.test.ts
+++ b/src/app/api/eth-balance/route.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllEnvs()
 })
 
 describe('GET /api/eth-balance', () => {
@@ -102,5 +103,29 @@ describe('GET /api/eth-balance', () => {
     )
 
     expect(JSON.stringify(await res.json())).not.toContain('Invalid API Key')
+  })
+
+  it('reports a non-OK Etherscan HTTP status as a bad gateway', async () => {
+    mswServer.use(
+      http.get(ETHERSCAN, () => new HttpResponse('forbidden', { status: 403 }))
+    )
+
+    const res = await GET(
+      buildAppRouteRequest(`/api/eth-balance?address=${ADDRESS}`)
+    )
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({
+      msg: 'Failed to fetch balance from Etherscan'
+    })
+  })
+
+  it('forwards the server API key on the upstream request', async () => {
+    vi.stubEnv('ETHERSCAN_API_KEY', 'server-key')
+    const requests = respondWith({ status: '1', result: '0' })
+
+    await GET(buildAppRouteRequest(`/api/eth-balance?address=${ADDRESS}`))
+
+    expect(requests[0].searchParams.get('apikey')).toBe('server-key')
   })
 })

--- a/src/app/api/eth-balance/route.ts
+++ b/src/app/api/eth-balance/route.ts
@@ -1,5 +1,5 @@
 import { ethAddressSchema } from '@/contracts/etherscan'
-import { buildEtherscanUrl, unwrapEtherscanResult } from '@/lib/etherscan'
+import { fetchEtherscanJson, unwrapEtherscanResult } from '@/lib/etherscan'
 import { NextResponse } from 'next/server'
 import { formatEther } from 'viem'
 
@@ -17,16 +17,14 @@ export const GET = async (req: Request) => {
   }
 
   try {
-    const res = await fetch(
-      buildEtherscanUrl({
+    const wei = unwrapEtherscanResult(
+      await fetchEtherscanJson({
         module: 'account',
         action: 'balance',
         address: address.data,
         tag: 'latest'
-      }),
-      { next: { revalidate: 15 } }
+      })
     )
-    const wei = unwrapEtherscanResult(await res.json())
 
     return NextResponse.json({
       address: address.data,

--- a/src/app/api/eth-transaction/route.ts
+++ b/src/app/api/eth-transaction/route.ts
@@ -1,5 +1,5 @@
 import { ethTransactionSchema, ethTxHashSchema } from '@/contracts/etherscan'
-import { buildEtherscanUrl, unwrapEtherscanProxyResult } from '@/lib/etherscan'
+import { fetchEtherscanJson, unwrapEtherscanProxyResult } from '@/lib/etherscan'
 import { NextResponse } from 'next/server'
 
 // GET /api/eth-transaction?hash=0x…
@@ -16,14 +16,13 @@ export const GET = async (req: Request) => {
   }
 
   try {
-    const res = await fetch(
-      buildEtherscanUrl({
+    const result = unwrapEtherscanProxyResult(
+      await fetchEtherscanJson({
         module: 'proxy',
         action: 'eth_getTransactionByHash',
         txhash: hash.data
       })
     )
-    const result = unwrapEtherscanProxyResult(await res.json())
 
     if (!result) {
       return NextResponse.json(

--- a/src/app/contact/_components/ContactForm.test.tsx
+++ b/src/app/contact/_components/ContactForm.test.tsx
@@ -1,3 +1,4 @@
+import ContactForm from '@/app/contact/_components/ContactForm'
 import type { ContactActionState } from '@/app/contact/state'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -22,12 +23,6 @@ vi.mock('react-toastify', () => ({ toast }))
 vi.mock('@marsidev/react-turnstile', async () =>
   (await import('@/test/mocks/turnstile')).turnstileMock()
 )
-
-const loadContactForm = async () => {
-  vi.resetModules()
-  const imported = await import('@/app/contact/_components/ContactForm')
-  return imported.default
-}
 
 const fillRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.type(
@@ -65,9 +60,7 @@ describe('ContactForm without Turnstile configured', () => {
     vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', '')
   })
 
-  it('renders every message field', async () => {
-    const ContactForm = await loadContactForm()
-
+  it('renders every message field', () => {
     render(<ContactForm />)
 
     expect(
@@ -81,16 +74,13 @@ describe('ContactForm without Turnstile configured', () => {
     ).toBeRequired()
   })
 
-  it('omits the security check widget', async () => {
-    const ContactForm = await loadContactForm()
-
+  it('omits the security check widget', () => {
     render(<ContactForm />)
 
     expect(screen.queryByTestId('turnstile-stub')).not.toBeInTheDocument()
   })
 
   it('reports a successful submission', async () => {
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)
@@ -110,7 +100,6 @@ describe('ContactForm without Turnstile configured', () => {
       resetKey: 0
     })
 
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)
@@ -132,7 +121,6 @@ describe('ContactForm without Turnstile configured', () => {
       resetKey: 1
     })
 
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)
@@ -149,16 +137,13 @@ describe('ContactForm with Turnstile configured', () => {
     vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', '1x00000000000000000000AA')
   })
 
-  it('renders the widget', async () => {
-    const ContactForm = await loadContactForm()
-
+  it('renders the widget', () => {
     render(<ContactForm />)
 
     expect(screen.getByTestId('turnstile-stub')).toBeInTheDocument()
   })
 
   it('blocks submission until the security check passes', async () => {
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)
@@ -172,7 +157,6 @@ describe('ContactForm with Turnstile configured', () => {
   })
 
   it('submits the token once the widget resolves', async () => {
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)
@@ -189,7 +173,6 @@ describe('ContactForm with Turnstile configured', () => {
   })
 
   it('blocks submission again after the token expires', async () => {
-    const ContactForm = await loadContactForm()
     const user = userEvent.setup()
 
     render(<ContactForm />)

--- a/src/app/contact/_components/ContactForm.tsx
+++ b/src/app/contact/_components/ContactForm.tsx
@@ -16,8 +16,6 @@ import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 import { useActionState, useEffect, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 
-const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
-
 const notifyContactResult = (state: ContactActionState) => {
   if (!state.msg?.length) return
 
@@ -43,6 +41,7 @@ const ContactForm = () => {
   const notifiedActionRef = useRef('')
   const [turnstileToken, setTurnstileToken] = useState('')
   const { msg, resetKey, success, emailSent } = state ?? initialContactState
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
   useEffect(() => {
     if (!msg?.length) return

--- a/src/app/portfolio/_components/Portfolio.test.tsx
+++ b/src/app/portfolio/_components/Portfolio.test.tsx
@@ -1,0 +1,38 @@
+import Portfolio from '@/app/portfolio/_components/Portfolio'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/image', async () =>
+  (await import('@/test/mocks/next')).nextImageMock()
+)
+
+describe('Portfolio', () => {
+  it('opens on Skills instead of the empty showcase', () => {
+    render(<Portfolio />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Skills', level: 2 })
+    ).toBeVisible()
+    expect(screen.getByRole('heading', { name: 'React' })).toBeVisible()
+    expect(screen.queryByText('Nothing to see here.')).not.toBeInTheDocument()
+  })
+
+  it('starts the showcase at the top after switching sections', async () => {
+    const user = userEvent.setup()
+    render(<Portfolio />)
+
+    const skillsPanel = screen.getByTestId('portfolio-showcase')
+    skillsPanel.scrollTop = 240
+
+    await user.click(screen.getByRole('button', { name: 'Projects' }))
+
+    expect(
+      screen.getByRole('heading', { name: 'Projects', level: 2 })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('heading', { name: 'Messenger Application' })
+    ).toBeVisible()
+    expect(screen.getByTestId('portfolio-showcase').scrollTop).toBe(0)
+  })
+})

--- a/src/app/portfolio/_components/Portfolio.tsx
+++ b/src/app/portfolio/_components/Portfolio.tsx
@@ -25,8 +25,12 @@ import {
 } from '@heroicons/react/24/solid'
 import { useState } from 'react'
 
+const SKILLS_CATEGORY = 0
+
 const Portfolio = () => {
-  const [activeCategory, setActiveCategory] = useState<number | null>(null)
+  const [activeCategory, setActiveCategory] = useState<number | null>(
+    SKILLS_CATEGORY
+  )
 
   const icons = [
     {
@@ -165,7 +169,11 @@ const Portfolio = () => {
         </div>
         <hr className="border-[0.3px] border-gray-300 dark:border-zinc-700 border-solid sm:order-1 md:hidden" />
         {activeCategory !== null ? (
-          <div className="flex flex-col py-5 sm:py-10 px-4 sm:px-12 gap-y-5 sm:gap-y-10 relative overflow-y-auto h-full w-full md:flex-1 bg-white/95 dark:bg-zinc-800/95">
+          <div
+            key={activeCategory}
+            data-testid="portfolio-showcase"
+            className="flex flex-col py-5 sm:py-10 px-4 sm:px-12 gap-y-5 sm:gap-y-10 relative overflow-y-auto h-full w-full md:flex-1 bg-white/95 dark:bg-zinc-800/95"
+          >
             {activeCategory === 0 &&
               skillCategories.map((category) => (
                 <div key={category} className="flex flex-col gap-y-4">

--- a/src/components/ResumeActionModal.test.tsx
+++ b/src/components/ResumeActionModal.test.tsx
@@ -1,0 +1,52 @@
+import ResumeActionModal from '@/components/ResumeActionModal'
+import ResumeDockItem from '@/components/ResumeDockItem'
+import { RESUME_HTML_HREF, RESUME_PDF_HREF } from '@/lib/resume'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/image', async () =>
+  (await import('@/test/mocks/next')).nextImageMock()
+)
+
+describe('ResumeActionModal', () => {
+  it('offers a PDF download and an HTML preview without starting either', () => {
+    render(<ResumeActionModal isOpen onClose={() => {}} />)
+
+    expect(screen.getByRole('dialog', { name: 'Resume' })).toBeVisible()
+
+    const pdf = screen.getByRole('link', { name: 'Download PDF' })
+    expect(pdf).toHaveAttribute('href', RESUME_PDF_HREF)
+    expect(pdf).toHaveAttribute('download')
+
+    const html = screen.getByRole('link', { name: 'View in browser' })
+    expect(html).toHaveAttribute('href', RESUME_HTML_HREF)
+    expect(html).toHaveAttribute('target', '_blank')
+  })
+
+  it('does not render while closed', () => {
+    render(<ResumeActionModal isOpen={false} onClose={() => {}} />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('ResumeDockItem', () => {
+  it('asks before downloading instead of navigating straight to the PDF', async () => {
+    const user = userEvent.setup()
+    render(<ResumeDockItem img="/images/icons/macOS-resume.png" />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Download PDF' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Resume' }))
+
+    expect(screen.getByRole('dialog', { name: 'Resume' })).toBeVisible()
+    expect(screen.getByRole('link', { name: 'Download PDF' })).toHaveAttribute(
+      'href',
+      RESUME_PDF_HREF
+    )
+  })
+})

--- a/src/components/ResumeActionModal.tsx
+++ b/src/components/ResumeActionModal.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { RESUME_HTML_HREF, RESUME_PDF_HREF } from '@/lib/resume'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+
+type ResumeActionModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const ResumeActionModal = ({ isOpen, onClose }: ResumeActionModalProps) => {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="resume-dialog-title"
+        className="w-full max-w-md rounded-xl bg-white dark:bg-zinc-900 shadow-2xl border border-gray-200 dark:border-zinc-700 overflow-hidden"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-zinc-700 bg-white/90 dark:bg-zinc-800/90">
+          <h2
+            id="resume-dialog-title"
+            className="text-base font-semibold text-gray-900 dark:text-white"
+          >
+            Resume
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-zinc-800 text-gray-500"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-4 space-y-4">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Download the PDF, or open the HTML version in this browser. Nothing
+            starts until you choose.
+          </p>
+          <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+            <a
+              href={RESUME_HTML_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-2 rounded-lg text-sm font-medium text-center text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-zinc-800"
+            >
+              View in browser
+            </a>
+            <a
+              href={RESUME_PDF_HREF}
+              download
+              className="px-4 py-2 rounded-lg text-sm font-medium text-center bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              Download PDF
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ResumeActionModal

--- a/src/components/ResumeDockItem.tsx
+++ b/src/components/ResumeDockItem.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import ResumeActionModal from '@/components/ResumeActionModal'
+import Image from 'next/image'
+import { useState } from 'react'
+
+type ResumeDockItemProps = {
+  img: string
+}
+
+const ResumeDockItem = ({ img }: ResumeDockItemProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Resume"
+        onClick={() => setIsOpen(true)}
+        className="flex flex-col items-center justify-center h-15 group cursor-pointer relative"
+      >
+        <span className="hidden -top-9 absolute left-1/2 transform -translate-x-1/2 px-2 py-1 bg-white/80 dark:bg-zinc-800/90 text-gray-800 dark:text-white text-xs font-medium rounded-md shadow-lg backdrop-blur-sm border border-white/20 dark:border-zinc-700/50 whitespace-nowrap group-hover:block opacity-0 group-hover:opacity-100 z-10">
+          Resume
+        </span>
+        <Image
+          alt="Resume"
+          src={img}
+          height={50}
+          width={50}
+          className="transition-all transform-gpu group-hover:scale-150 drop-shadow-none group-hover:drop-shadow-md"
+          style={{
+            transition: 'all 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)',
+            transformOrigin: 'bottom'
+          }}
+        />
+      </button>
+      <ResumeActionModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  )
+}
+
+export default ResumeDockItem

--- a/src/components/layouts/index.tsx
+++ b/src/components/layouts/index.tsx
@@ -2,6 +2,7 @@
 
 import DeviceStatus from '@/components/DeviceStatus'
 import DisplayTime from '@/components/DisplayTime'
+import ResumeDockItem from '@/components/ResumeDockItem'
 import ThemeToggle from '@/components/ThemeToggle'
 import { isAdminRole } from '@/lib/admin'
 import { signIn, signOut, useSession } from 'next-auth/react'
@@ -9,6 +10,14 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
+
+interface DockItemType {
+  name: string
+  title: string
+  img: string
+  path?: string
+  click?: () => void
+}
 
 const ResponsiveUI = ({
   children
@@ -117,12 +126,11 @@ const ResponsiveUI = ({
   ]
 
   // Group 2: Documents & Files
-  const dockGroup2 = [
+  const dockGroup2: DockItemType[] = [
     {
       name: 'resume',
-      title: 'Download Resume',
-      img: '/images/icons/macOS-resume.png',
-      path: '/pdfs/updated-resume.pdf'
+      title: 'Resume',
+      img: '/images/icons/macOS-resume.png'
     }
   ]
 
@@ -248,13 +256,13 @@ const ResponsiveUI = ({
       {children}
 
       {/* Mobile Footer/Dock */}
-      <footer className='flex w-full xs:w-[unset] xs:gap-x-[30px] sm:gap-x-4 py-5 px-5 sm:px-7 sm:py-4 before:absolute before:content-[""] before:bg-[#BFBFBF70]/44 before:backdrop-blur-[50px] before:-z-10 bg-white/20 dark:bg-black/20 hover:bg-white/30 dark:hover:bg-black/30 rounded-none xs:rounded-[40px] sm:rounded-[30px] before:content items-center justify-around xs:justify-center my-0 xs:my-3 sm:my-4 xl:hidden'>
+      <footer className='flex w-full xs:w-[unset] xs:gap-x-7.5 sm:gap-x-4 py-5 px-5 sm:px-7 sm:py-4 before:absolute before:content-[""] before:bg-[#BFBFBF70]/44 before:backdrop-blur-[50px] before:-z-10 bg-white/20 dark:bg-black/20 hover:bg-white/30 dark:hover:bg-black/30 rounded-none xs:rounded-[40px] sm:rounded-[30px] before:content items-center justify-around xs:justify-center my-0 xs:my-3 sm:my-4 xl:hidden'>
         {dock.map((item) =>
           item.click ? (
             <button
               onClick={item.click}
               key={item.name}
-              className="relative xs:h-[60px] xs:w-[60px] h-10 w-10"
+              className="relative xs:h-15 xs:w-15 h-10 w-10"
             >
               <Image
                 alt={item.name}
@@ -266,7 +274,7 @@ const ResponsiveUI = ({
             </button>
           ) : (
             <Link href={`${item.path}`} key={item.name} className="block">
-              <div className="relative xs:h-[60px] xs:w-[60px] h-10 w-10">
+              <div className="relative xs:h-15 xs:w-15 h-10 w-10">
                 <Image
                   alt={item.name}
                   src={item.img}
@@ -315,16 +323,6 @@ const ResponsiveUI = ({
   )
 }
 
-// Define the dock item type
-interface DockItemType {
-  name: string
-  title: string
-  img: string
-  path?: string
-  click?: () => void
-}
-
-// Extract dock item to a separate component to avoid repetition
 const DockItem = ({
   item,
   pathname
@@ -338,7 +336,7 @@ const DockItem = ({
     return (
       <button
         onClick={item.click}
-        className="flex flex-col items-center justify-center h-[60px] group cursor-pointer relative"
+        className="flex flex-col items-center justify-center h-15 group cursor-pointer relative"
       >
         <span className="hidden -top-9 absolute left-1/2 transform -translate-x-1/2 px-2 py-1 bg-white/80 dark:bg-zinc-800/90 text-gray-800 dark:text-white text-xs font-medium rounded-md shadow-lg backdrop-blur-sm border border-white/20 dark:border-zinc-700/50 whitespace-nowrap group-hover:block opacity-0 group-hover:opacity-100 z-10">
           {item.title}
@@ -359,33 +357,8 @@ const DockItem = ({
     )
   }
 
-  if (item.name === 'resume' && item.path) {
-    return (
-      <Link
-        href={item.path}
-        target={'_blank'}
-        download
-        className="flex flex-col items-center justify-center h-[60px] group cursor-pointer relative"
-      >
-        <span className="hidden -top-9 absolute left-1/2 transform -translate-x-1/2 px-2 py-1 bg-white/80 dark:bg-zinc-800/90 text-gray-800 dark:text-white text-xs font-medium rounded-md shadow-lg backdrop-blur-sm border border-white/20 dark:border-zinc-700/50 whitespace-nowrap group-hover:block opacity-0 group-hover:opacity-100 z-10">
-          {item.title}
-        </span>
-        <Image
-          alt={item.name}
-          src={item.img}
-          height={50}
-          width={50}
-          className="transition-all transform-gpu group-hover:scale-150 drop-shadow-none group-hover:drop-shadow-md"
-          style={{
-            transition: 'all 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)',
-            transformOrigin: 'bottom'
-          }}
-        />
-        {isActive && (
-          <span className="h-1 w-1 bg-blue-500 dark:bg-blue-400 rounded-full" />
-        )}
-      </Link>
-    )
+  if (item.name === 'resume') {
+    return <ResumeDockItem img={item.img} />
   }
 
   // Only render Link if path exists
@@ -393,7 +366,7 @@ const DockItem = ({
     return (
       <Link
         href={item.path}
-        className="flex flex-col items-center justify-center h-[60px] group cursor-pointer relative"
+        className="flex flex-col items-center justify-center h-15 group cursor-pointer relative"
       >
         <span className="hidden -top-9 absolute left-1/2 transform -translate-x-1/2 px-2 py-1 bg-white/80 dark:bg-zinc-800/90 text-gray-800 dark:text-white text-xs font-medium rounded-md shadow-lg backdrop-blur-sm border border-white/20 dark:border-zinc-700/50 whitespace-nowrap group-hover:block opacity-0 group-hover:opacity-100 z-10">
           {item.title}
@@ -418,7 +391,7 @@ const DockItem = ({
 
   // Fallback for items without path or click handler
   return (
-    <div className="flex flex-col items-center justify-center h-[60px] group cursor-pointer relative">
+    <div className="flex flex-col items-center justify-center h-15 group cursor-pointer relative">
       <span className="hidden -top-9 absolute left-1/2 transform -translate-x-1/2 px-2 py-1 bg-white/80 dark:bg-zinc-800/90 text-gray-800 dark:text-white text-xs font-medium rounded-md shadow-lg backdrop-blur-sm border border-white/20 dark:border-zinc-700/50 whitespace-nowrap group-hover:block opacity-0 group-hover:opacity-100 z-10">
         {item.title}
       </span>

--- a/src/lib/etherscan.test.ts
+++ b/src/lib/etherscan.test.ts
@@ -1,9 +1,18 @@
 import {
   buildEtherscanUrl,
+  fetchEtherscanJson,
   unwrapEtherscanProxyResult,
   unwrapEtherscanResult
 } from '@/lib/etherscan'
-import { describe, expect, it } from 'vitest'
+import { mswServer } from '@/test/msw/nodeServer'
+import { HttpResponse, http } from 'msw'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const ETHERSCAN = 'https://api.etherscan.io/v2/api'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('buildEtherscanUrl', () => {
   it('targets the V2 endpoint with the mainnet chain id', () => {
@@ -87,5 +96,41 @@ describe('unwrapEtherscanProxyResult', () => {
     expect(() =>
       unwrapEtherscanProxyResult({ error: { message: 'invalid argument 0' } })
     ).toThrow('invalid argument 0')
+  })
+})
+
+describe('Etherscan API key', () => {
+  it('sends the server key and ignores the leftover public name', () => {
+    vi.stubEnv('ETHERSCAN_API_KEY', 'server-key')
+    vi.stubEnv('NEXT_PUBLIC_ETHERSCAN_API_KEY', 'public-key')
+
+    const url = new URL(
+      buildEtherscanUrl({ module: 'account', action: 'balance' })
+    )
+
+    expect(url.searchParams.get('apikey')).toBe('server-key')
+  })
+
+  it('still attaches a key after the public env name was the only one set', () => {
+    vi.stubEnv('ETHERSCAN_API_KEY', '')
+    vi.stubEnv('NEXT_PUBLIC_ETHERSCAN_API_KEY', 'public-key')
+
+    const url = new URL(
+      buildEtherscanUrl({ module: 'account', action: 'balance' })
+    )
+
+    expect(url.searchParams.get('apikey')).toBe('public-key')
+  })
+})
+
+describe('fetchEtherscanJson', () => {
+  it('throws on a non-OK HTTP status instead of parsing HTML as JSON', async () => {
+    mswServer.use(
+      http.get(ETHERSCAN, () => new HttpResponse('forbidden', { status: 403 }))
+    )
+
+    await expect(
+      fetchEtherscanJson({ module: 'account', action: 'balance' })
+    ).rejects.toThrow('Etherscan HTTP 403')
   })
 })

--- a/src/lib/etherscan.ts
+++ b/src/lib/etherscan.ts
@@ -18,11 +18,37 @@ export const buildEtherscanUrl = (params: Record<string, string>) => {
     url.searchParams.set(key, value)
   }
 
-  const apiKey = process.env.ETHERSCAN_API_KEY
+  const apiKey = getEtherscanApiKey()
 
   if (apiKey) url.searchParams.set('apikey', apiKey)
 
   return url.toString()
+}
+
+/**
+ * Server-only. Prefers `ETHERSCAN_API_KEY` (never shipped to the client) and
+ * falls back to the old public name so a deploy that only renamed the code
+ * still has a key.
+ */
+export const getEtherscanApiKey = () =>
+  process.env.ETHERSCAN_API_KEY ||
+  process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY ||
+  ''
+
+export const fetchEtherscanJson = async (params: Record<string, string>) => {
+  const res = await fetch(buildEtherscanUrl(params), {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'jeraldbaroro.xyz eth-proxy'
+    }
+  })
+
+  if (!res.ok) {
+    throw new Error(`Etherscan HTTP ${res.status}`)
+  }
+
+  return res.json() as Promise<EtherscanEnvelope>
 }
 
 type EtherscanEnvelope = {

--- a/src/lib/resume.ts
+++ b/src/lib/resume.ts
@@ -1,0 +1,2 @@
+export const RESUME_PDF_HREF = '/pdfs/updated-resume.pdf'
+export const RESUME_HTML_HREF = '/resume/resume.html'

--- a/src/lib/route-guard.test.ts
+++ b/src/lib/route-guard.test.ts
@@ -1,0 +1,95 @@
+import {
+  decideAuthRedirect,
+  isDiaryWriteRoute,
+  isSessionProtectedRoute
+} from '@/lib/route-guard'
+import { describe, expect, it } from 'vitest'
+
+describe('isDiaryWriteRoute', () => {
+  it('treats create and edit as write routes', () => {
+    expect(isDiaryWriteRoute('/diary')).toBe(true)
+    expect(isDiaryWriteRoute('/diary/abc/edit')).toBe(true)
+    expect(isDiaryWriteRoute('/diary/abc/edit/')).toBe(true)
+  })
+
+  it('leaves public diary reading alone', () => {
+    expect(isDiaryWriteRoute('/diaries')).toBe(false)
+    expect(isDiaryWriteRoute('/diary/abc')).toBe(false)
+  })
+})
+
+describe('isSessionProtectedRoute', () => {
+  it('guards chess, mails, admin, and diary writes', () => {
+    expect(isSessionProtectedRoute('/chess')).toBe(true)
+    expect(isSessionProtectedRoute('/chess/line/1')).toBe(true)
+    expect(isSessionProtectedRoute('/mails')).toBe(true)
+    expect(isSessionProtectedRoute('/admin/tools')).toBe(true)
+    expect(isSessionProtectedRoute('/diary')).toBe(true)
+  })
+
+  it('does not guard public pages', () => {
+    expect(isSessionProtectedRoute('/')).toBe(false)
+    expect(isSessionProtectedRoute('/portfolio')).toBe(false)
+    expect(isSessionProtectedRoute('/contact')).toBe(false)
+    expect(isSessionProtectedRoute('/diaries')).toBe(false)
+  })
+})
+
+describe('decideAuthRedirect', () => {
+  const decide = (
+    pathname: string,
+    session: { isAuthenticated: boolean; isAdmin: boolean }
+  ) => decideAuthRedirect({ pathname, ...session })
+
+  const signedOut = { isAuthenticated: false, isAdmin: false }
+  const user = { isAuthenticated: true, isAdmin: false }
+  const admin = { isAuthenticated: true, isAdmin: true }
+
+  it('sends signed-out visitors home from chess and mails', () => {
+    expect(decide('/chess', signedOut)).toEqual({
+      type: 'redirect',
+      pathname: '/'
+    })
+    expect(decide('/mails', signedOut)).toEqual({
+      type: 'redirect',
+      pathname: '/'
+    })
+  })
+
+  it('lets an authenticated admin through to chess and mails', () => {
+    expect(decide('/chess', admin)).toEqual({ type: 'next' })
+    expect(decide('/mails', admin)).toEqual({ type: 'next' })
+  })
+
+  it('lets a signed-in non-admin through to chess', () => {
+    expect(decide('/chess', user)).toEqual({ type: 'next' })
+  })
+
+  it('sends a signed-in non-admin away from mails', () => {
+    expect(decide('/mails', user)).toEqual({
+      type: 'redirect',
+      pathname: '/'
+    })
+  })
+
+  it('sends an admin from contact to the inbox', () => {
+    expect(decide('/contact', admin)).toEqual({
+      type: 'redirect',
+      pathname: '/mails'
+    })
+  })
+
+  it('leaves contact open for everyone else', () => {
+    expect(decide('/contact', signedOut)).toEqual({ type: 'next' })
+    expect(decide('/contact', user)).toEqual({ type: 'next' })
+  })
+
+  it('does not treat a missing session as an admin', () => {
+    expect(decide('/mails', { isAuthenticated: false, isAdmin: true })).toEqual(
+      { type: 'redirect', pathname: '/' }
+    )
+    expect(decide('/chess', { isAuthenticated: false, isAdmin: true })).toEqual(
+      { type: 'redirect', pathname: '/' }
+    )
+  })
+})

--- a/src/lib/route-guard.ts
+++ b/src/lib/route-guard.ts
@@ -1,0 +1,45 @@
+export const SESSION_PROTECTED_ROUTES = ['/mails', '/admin', '/chess']
+
+export const isDiaryWriteRoute = (pathname: string) =>
+  pathname === '/diary' || /^\/diary\/[^/]+\/edit\/?$/.test(pathname)
+
+export const isSessionProtectedRoute = (pathname: string) =>
+  SESSION_PROTECTED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  ) || isDiaryWriteRoute(pathname)
+
+export type AuthRedirectDecision =
+  { type: 'next' } | { type: 'redirect'; pathname: string }
+
+/**
+ * Page-level gate used by `src/proxy.ts`. API routes still enforce auth
+ * themselves — this only decides whether the document request may proceed.
+ *
+ * `isAuthenticated` must come from Auth.js `auth()` (the session), not from
+ * `getToken()`. The JWT helper is a v4 leftover and does not read the v5
+ * production cookie (`__Secure-authjs.session-token` + salt), so a signed-in
+ * admin looks logged-out and `/chess` / `/mails` bounce home.
+ */
+export const decideAuthRedirect = ({
+  pathname,
+  isAuthenticated,
+  isAdmin
+}: {
+  pathname: string
+  isAuthenticated: boolean
+  isAdmin: boolean
+}): AuthRedirectDecision => {
+  if (pathname.startsWith('/contact') && isAdmin) {
+    return { type: 'redirect', pathname: '/mails' }
+  }
+
+  if (pathname.startsWith('/mails') && isAuthenticated && !isAdmin) {
+    return { type: 'redirect', pathname: '/' }
+  }
+
+  if (!isAuthenticated && isSessionProtectedRoute(pathname)) {
+    return { type: 'redirect', pathname: '/' }
+  }
+
+  return { type: 'next' }
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { adminSession, userSession, type TestSession } from '@/test/mocks/auth'
+import type { NextFetchEvent } from 'next/server'
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sessionState = vi.hoisted(() => ({
+  current: null as TestSession
+}))
+
+vi.mock('@/auth', () => ({
+  auth:
+    (handler: (request: NextRequest & { auth: TestSession }) => unknown) =>
+    (request: NextRequest) => {
+      const authed = Object.assign(request, { auth: sessionState.current })
+      return handler(authed)
+    }
+}))
+
+const { proxy } = await import('@/proxy')
+
+type ProxyFn = (
+  request: NextRequest,
+  event: NextFetchEvent
+) => Response | void | Promise<Response | void>
+
+const handleProxy = proxy as unknown as ProxyFn
+
+const requestFor = (pathname: string) =>
+  new NextRequest(new URL(pathname, 'https://jeraldbaroro.xyz'))
+
+const dummyEvent = {} as NextFetchEvent
+
+const runProxy = async (pathname: string) => {
+  const response = await handleProxy(requestFor(pathname), dummyEvent)
+
+  if (!response) {
+    throw new Error(`proxy returned void for ${pathname}`)
+  }
+
+  return response
+}
+
+const locationOf = (response: Response) =>
+  new URL(response.headers.get('location') ?? '', 'https://jeraldbaroro.xyz')
+    .pathname
+
+describe('proxy auth gate', () => {
+  beforeEach(() => {
+    sessionState.current = null
+  })
+
+  afterEach(() => {
+    sessionState.current = null
+  })
+
+  it('redirects signed-out visitors away from chess and mails', async () => {
+    const chess = await runProxy('/chess')
+    const mails = await runProxy('/mails')
+
+    expect(chess.status).toBe(307)
+    expect(locationOf(chess)).toBe('/')
+    expect(mails.status).toBe(307)
+    expect(locationOf(mails)).toBe('/')
+  })
+
+  it('lets an authenticated admin through to chess and mails', async () => {
+    sessionState.current = adminSession()
+
+    const chess = await runProxy('/chess')
+    const mails = await runProxy('/mails')
+
+    expect(chess.status).not.toBe(307)
+    expect(mails.status).not.toBe(307)
+    expect(chess.headers.get('location')).toBeNull()
+    expect(mails.headers.get('location')).toBeNull()
+  })
+
+  it('lets a signed-in non-admin through to chess but not mails', async () => {
+    sessionState.current = userSession()
+
+    const chess = await runProxy('/chess')
+    const mails = await runProxy('/mails')
+
+    expect(chess.status).not.toBe(307)
+    expect(mails.status).toBe(307)
+    expect(locationOf(mails)).toBe('/')
+  })
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,41 +1,31 @@
+import { auth } from '@/auth'
 import { isAdminRole } from '@/lib/admin'
-import { getToken } from 'next-auth/jwt'
-import type { NextRequest } from 'next/server'
+import { decideAuthRedirect } from '@/lib/route-guard'
 import { NextResponse } from 'next/server'
 
-const SESSION_PROTECTED_ROUTES = ['/mails', '/admin', '/chess']
-
-const isDiaryWriteRoute = (pathname: string) =>
-  pathname === '/diary' || /^\/diary\/[^/]+\/edit\/?$/.test(pathname)
-
-const isSessionProtectedRoute = (pathname: string) =>
-  SESSION_PROTECTED_ROUTES.some(
-    (route) => pathname === route || pathname.startsWith(`${route}/`)
-  ) || isDiaryWriteRoute(pathname)
-
-export const proxy = async (request: NextRequest) => {
+/**
+ * Use Auth.js `auth()`, not `getToken()` from `next-auth/jwt`.
+ * `getToken` is a v4 helper and does not decode v5 production cookies, so a
+ * signed-in admin is treated as logged-out and `/chess` / `/mails` redirect
+ * home. `auth()` is the same reader the rest of the app already uses.
+ */
+export const proxy = auth((request) => {
   const { pathname } = request.nextUrl
-  const token = await getToken({
-    req: request,
-    secret: process.env.AUTH_SECRET
+  const isAuthenticated = Boolean(request.auth?.user)
+  const isAdmin = isAdminRole(request.auth?.user?.role)
+
+  const decision = decideAuthRedirect({
+    pathname,
+    isAuthenticated,
+    isAdmin
   })
-  const isAuthenticated = Boolean(token)
-  const isAdmin = isAdminRole(token?.role as string | undefined)
 
-  if (pathname.startsWith('/contact') && isAdmin) {
-    return NextResponse.redirect(new URL('/mails', request.url))
-  }
-
-  if (pathname.startsWith('/mails') && isAuthenticated && !isAdmin) {
-    return NextResponse.redirect(new URL('/', request.url))
-  }
-
-  if (!isAuthenticated && isSessionProtectedRoute(pathname)) {
-    return NextResponse.redirect(new URL('/', request.url))
+  if (decision.type === 'redirect') {
+    return NextResponse.redirect(new URL(decision.pathname, request.url))
   }
 
   return NextResponse.next()
-}
+})
 
 export const config = {
   matcher: [

--- a/src/test/mocks/next.tsx
+++ b/src/test/mocks/next.tsx
@@ -9,7 +9,7 @@
  * )
  * ```
  */
-import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import type { AnchorHTMLAttributes, CSSProperties, ReactNode } from 'react'
 import { vi } from 'vitest'
 
 export const routerMock = {
@@ -65,4 +65,35 @@ export const nextLinkMock = () => ({
       {children}
     </a>
   )
+})
+
+type ImageProps = {
+  alt?: string
+  src: string
+  fill?: boolean
+  priority?: boolean
+  sizes?: string
+  quality?: number
+  width?: number
+  height?: number
+  className?: string
+  style?: CSSProperties
+}
+
+export const nextImageMock = () => ({
+  default: (props: ImageProps) => {
+    const { alt = '', src, width, height, className, style } = props
+
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        alt={alt}
+        src={typeof src === 'string' ? src : ''}
+        width={width}
+        height={height}
+        className={className}
+        style={style}
+      />
+    )
+  }
 })


### PR DESCRIPTION
## Summary
- Keep signed-in admins on `/chess` and `/mails` in production by reading the Auth.js session through `auth()` in `proxy.ts`. `getToken()` is a v4 leftover and does not decode v5 production cookies, so a logged-in admin looked signed-out and bounced home.
- Fix the Web3 `502` on `/api/eth-balance` after the Etherscan key left the client. The server proxy now prefers `ETHERSCAN_API_KEY`, falls back to the old public name, and skips Next's fetch cache.
- Open Portfolio on Skills instead of the empty showcase, remount the panel so section switches start at the top, and confirm resume download vs HTML view instead of fetching a PDF on every dock click.
- Stop ContactForm tests from `vi.resetModules()` on every case (the first load blew the 5s timeout and leaked fields). The Turnstile key is read at render time.

## Test plan
- [ ] `yarn validate` — format, lint, `tsc --noEmit`, unit tests, Playwright, production build
- [ ] Signed in as admin, `/chess` loads the repertoire and `/mails` stays on the inbox (no redirect to `/`)
- [ ] `/web3` shows the real MetaMask balance; `/api/eth-balance` returns 200 with `ETHERSCAN_API_KEY` set
- [ ] `/portfolio` opens on Skills; switching to Projects resets showcase scroll to the top
- [ ] Dock Resume icon opens a dialog with Download PDF and View in browser; nothing downloads until you choose
- [ ] Contact form still submits with and without Turnstile; `yarn test ContactForm` stays green