### PR TITLE
chore(web3): drop leftover public Etherscan key fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ NEXT_PUBLIC_NEWS_DATA_API_KEY=
 # The address shown in the "My MetaMask" panel; public by nature.
 NEXT_PUBLIC_METAMASK_ADDRESS=
 # Server-side only: /api/eth-balance and /api/eth-transaction proxy Etherscan so
-# the key is never shipped to the browser. Etherscan V1 is retired — the key
-# must be a V2 key from https://etherscan.io/myapikey
+# the key is never shipped to the browser. Do not set NEXT_PUBLIC_ETHERSCAN_API_KEY;
+# that leftover name is ignored. Etherscan V1 is retired — the key must be a V2
+# key from https://etherscan.io/myapikey
 ETHERSCAN_API_KEY=
 
 NEXT_PUBLIC_TINYMCE_API_KEY=

--- a/src/lib/etherscan.test.ts
+++ b/src/lib/etherscan.test.ts
@@ -111,7 +111,7 @@ describe('Etherscan API key', () => {
     expect(url.searchParams.get('apikey')).toBe('server-key')
   })
 
-  it('still attaches a key after the public env name was the only one set', () => {
+  it('does not fall back to the leftover public env name', () => {
     vi.stubEnv('ETHERSCAN_API_KEY', '')
     vi.stubEnv('NEXT_PUBLIC_ETHERSCAN_API_KEY', 'public-key')
 
@@ -119,7 +119,7 @@ describe('Etherscan API key', () => {
       buildEtherscanUrl({ module: 'account', action: 'balance' })
     )
 
-    expect(url.searchParams.get('apikey')).toBe('public-key')
+    expect(url.searchParams.get('apikey')).toBeNull()
   })
 })
 

--- a/src/lib/etherscan.ts
+++ b/src/lib/etherscan.ts
@@ -25,15 +25,8 @@ export const buildEtherscanUrl = (params: Record<string, string>) => {
   return url.toString()
 }
 
-/**
- * Server-only. Prefers `ETHERSCAN_API_KEY` (never shipped to the client) and
- * falls back to the old public name so a deploy that only renamed the code
- * still has a key.
- */
-export const getEtherscanApiKey = () =>
-  process.env.ETHERSCAN_API_KEY ||
-  process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY ||
-  ''
+/** Server-only. Reads `ETHERSCAN_API_KEY`; the leftover public name is ignored. */
+export const getEtherscanApiKey = () => process.env.ETHERSCAN_API_KEY ?? ''
 
 export const fetchEtherscanJson = async (params: Record<string, string>) => {
   const res = await fetch(buildEtherscanUrl(params), {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,12 +18,11 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       /**
-       * Without `all`, v8 only counts files some test imported, so untested
-       * modules vanish from the denominator and the percentage reads far
-       * higher than it is. `skipFull` then keeps the table down to the files
-       * that still need work.
+       * Vitest 4 dropped `coverage.all`. `include` is what pulls untested
+       * files into the denominator so the percentage is not only the modules
+       * a test imported. `skipFull` keeps the table down to files that still
+       * need work.
        */
-      all: true,
       skipFull: true,
       include: ['src/**/*.{ts,tsx}'],
       exclude: [


### PR DESCRIPTION
## Summary
- `/api/eth-balance` and `/api/eth-transaction` now attach only `ETHERSCAN_API_KEY`. The leftover `NEXT_PUBLIC_ETHERSCAN_API_KEY` name is ignored.
- After merge, delete `NEXT_PUBLIC_ETHERSCAN_API_KEY` from Vercel so the key is not shipped to the client. Keep `ETHERSCAN_API_KEY`.

## Test plan
- [ ] `yarn validate` (already green on this branch)
- [ ] Confirm `/web3` still loads a balance in production after deploy
- [ ] Remove `NEXT_PUBLIC_ETHERSCAN_API_KEY` from the Vercel project env